### PR TITLE
app.js: renamed callback parameter to createdTweet to prevent namecollis...

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,12 +47,12 @@ t.on('tweet', function(twdata){
 
     console.log(newTweet);
 
-    newTweet.save(function(err, newTweet){
+    newTweet.save(function(err, createdTweet){
         if(err){
             console.log(err);
         }
         else{
-            console.dir(newTweet);
+            console.dir(createdTweet);
         }
 
     });

--- a/data/schemas/tweet.js
+++ b/data/schemas/tweet.js
@@ -4,11 +4,11 @@
 var mongoose = require('mongoose');
 
 var tweetSchema = new mongoose.Schema({
-    userName: {type: String},
-    imageUrl: {type:String},
-    bannerUrl: {type:String},
-    text: {type:String},
-    hashTag: {type:String}
+    userName: 'string',
+    imageUrl: 'string',
+    bannerUrl: 'string',
+    text: 'string',
+    hashTag: 'string'
 });
 
-module.Exports = tweetSchema;
+module.exports = tweetSchema;


### PR DESCRIPTION
app.js: renamed callback parameter to createdTweet to prevent name collision, (I'm not sure if it's the same object, haven't used mongoose yet)

tweet.js: tried changing the schema but that wasn't the bug. module.Exports should be module.exports.

Because of the uppercase typo, nothing was returned when calling require('../schema/tweet.js') in './model/tweet.js.
Hence, passing in undefined to the mongoose.model('Tweet',TweetSchema,"tweets") in './model/tweet.js' and creating empty database documents.
